### PR TITLE
แก้ไขเรื่องอักขระพิเศษในชื่อของหน่วยงาน

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-  - oraclejdk8
   - openjdk8
 
 before_cache:
@@ -10,7 +9,6 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-    -
 deploy:
   provider: releases
   api_key: "$GITHUB_OAUTH_TOKEN"

--- a/src/main/kotlin/ffc.airsync.api/services/genogram/MongoRelationsShipDao.kt
+++ b/src/main/kotlin/ffc.airsync.api/services/genogram/MongoRelationsShipDao.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2019 NECTEC
+ *   National Electronics and Computer Technology Center, Thailand
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package ffc.airsync.api.services.genogram
 
 import com.mongodb.BasicDBObject
@@ -59,13 +77,21 @@ class MongoRelationsShipDao : MongoDao("ffc", "person"), GenoGramDao {
             collect[personId] = persons.getPerson(orgId, personId)
 
         relation.forEach { personRelation ->
-            if (personRelation.id.isNotBlank() && collect[personRelation.id] == null) {
-                val person = persons.getPerson(orgId, personRelation.id)
-                collect[personRelation.id] = person
-                collectPerson(orgId, personRelation.id, collect)
+            if (fixCheckPersonIdIsNotBank(personRelation)) {
+                if (collect[personRelation.id] == null) {
+                    val person = persons.getPerson(orgId, personRelation.id)
+                    collect[personRelation.id] = person
+                    collectPerson(orgId, personRelation.id, collect)
+                }
             }
         }
         return collect
+    }
+
+    private fun fixCheckPersonIdIsNotBank(personRelation: Person.Relationship): Boolean {
+        val run = runCatching { personRelation.id.isNotBlank() }
+        return if (run.isSuccess) run.getOrThrow()
+        else false
     }
 
     override fun removeByOrgId(orgId: String) {

--- a/src/main/kotlin/ffc.airsync.api/services/org/OrgDao.kt
+++ b/src/main/kotlin/ffc.airsync.api/services/org/OrgDao.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 NECTEC
+ * Copyright (c) 2019 NECTEC
  *   National Electronics and Computer Technology Center, Thailand
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package ffc.airsync.api.services.org
@@ -32,11 +33,10 @@ interface OrgDao : Dao {
 }
 
 val orgs: OrgDao by lazy { MongoOrgDao() }
-private const val thaiCharacters = """เแโไใกขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรลวศษสหฬอฮa-zA-Z"""
-private const val thaiVowels = """ะาิีึืุูัํำ่้๊๋็์ฤฦ0-9\-"""
-private val thaiRegx = Regex("^[$thaiCharacters][$thaiCharacters$thaiVowels]+\$")
+
+private val dontRecive = Regex(""".*[\.\,\|\(\)\ ].*""")
 
 /**
  * ตรวจสอบ Organization name ว่าอยู่ในเงื่อนไขในการตั้งชื่อหรือไม่
  */
-fun Organization.isAcceptName(): Boolean = thaiRegx.matches(this.name)
+fun Organization.isAcceptName(): Boolean = !dontRecive.matches(this.name)

--- a/src/test/kotlin/ffc/airsync/api/services/org/MongoOrgDaoTest.kt
+++ b/src/test/kotlin/ffc/airsync/api/services/org/MongoOrgDaoTest.kt
@@ -232,6 +232,30 @@ class MongoOrgDaoTest {
     }
 
     @Test
+    fun testBug2() {
+
+        val maeOrg = dao.insert(Org("โรงพยาบาลส่งเสริมสุขภาพตำบลแม่ข้าวต้มฯ", "192.168.99.3").apply {
+            displayName = "รพ.สต.โรงพยาบาลส่งเสริมสุขภาพตำบลแม่ข้าวต้ม"
+            tel = "037-261-044"
+            address = "161 ม.29 ต.สง่างาม อ.สดใส จ.ผิวผ่อง"
+            link!!.keys["pcucode"] = "203"
+        })
+        maeOrg.isAcceptName() `should be equal to` true
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testBug3() {
+
+        val maeOrg = dao.insert(Org("โรงพยาบาลส่งเสริมสุข, ภาพตำบลแม่ข้าว-ต้ม", "192.168.99.3").apply {
+            displayName = "รพ.สต.โรงพยาบาลส่งเสริมสุขภาพตำบลแม่ข้าวต้ม"
+            tel = "037-261-044"
+            address = "161 ม.29 ต.สง่างาม อ.สดใส จ.ผิวผ่อง"
+            link!!.keys["pcucode"] = "203"
+        })
+        maeOrg.isAcceptName() `should be equal to` false
+    }
+
+    @Test
     fun activateUser() {
         val maeOrg = dao.insert(Org("โรงพยาบาลส่งเสริมสุขภาพตำบลแม่ข้าวต้ม", "192.168.99.3").apply {
             displayName = "รพ.สต.โรงพยาบาลส่งเสริมสุขภาพตำบลแม่ข้าวต้ม"


### PR DESCRIPTION
พบว่าชื่อของหน่วยงานมีการใช้อักขระพิเศษหลายตัวเช่น ฯ ํ อื่นๆ
เปลี่ยนกฏจากตรวจสอบว่า ต้องรองรับชื่อแบบไหนบ้าง เป็น ชื่อที่มีอักขระอะไรบ้างที่ไม่ยอมรับ